### PR TITLE
fix: error on push updates + conflicts resolving

### DIFF
--- a/src/jobs/push.ts
+++ b/src/jobs/push.ts
@@ -139,11 +139,13 @@ export const push = async (
     await pullRemoteBranchIntoCurrentBranch(
         'Upstream',
         upstreamGit,
-        // TODO: should we merge the revision which current slice's default branch is synced as
-        // instead of upstream's default branch which can be missed matching..
-        // actionInputs.upstreamRepo.defaultBranch,
+        // we merge the revision which current slice's default branch is synced at
+        // instead of upstream's default branch which can be missed matching while running in parallel
         currentSyncUpstreamCommitId,
-        upstreamBranch
+        upstreamBranch,
+        // We ignore merging error on upstream to allow pushing updates when there are conflicts on upstream repo.
+        // In this case, commit below will contain both updates + merge base commit
+        true
     )
 
     terminal('Done!\n')

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,3 +16,8 @@ export interface Repo {
     gitHttpUri: string
     userToken: string
 }
+
+export interface ErrorLike {
+    message: string
+    name?: string
+}


### PR DESCRIPTION
## Description

- Add new arg which allows us to skip merging conflicts when pulling changes from base branch.
- This will help us to push updates of a having conflicts branch on upstream repo